### PR TITLE
Failed flutter android build

### DIFF
--- a/lib/services/listing_service.dart
+++ b/lib/services/listing_service.dart
@@ -68,7 +68,7 @@ class ListingService {
       }
 
       // Apply sorting and pagination in a single chain
-      PostgrestFilterBuilder<List<Map<String, dynamic>>> finalQuery;
+      var finalQuery = query;
       if (sortBy == 'Price (Low to High)') {
         finalQuery = query.order('price', ascending: true);
       } else if (sortBy == 'Price (High to Low)') {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,8 @@ dependencies:
   
   # Location Services
   geolocator: ^11.1.0
+  google_places_flutter: ^2.0.6
+  google_api_headers: ^1.3.0
   
   # Image Handling
   image_picker: ^1.0.7


### PR DESCRIPTION
Fix Android build by adding missing dependencies and resolving Postgrest type conflicts.

The build failed due to missing `google_places_flutter` and `google_api_headers` packages, and a type mismatch in `listing_service.dart` where `PostgrestTransformBuilder` could not be assigned to `PostgrestFilterBuilder` after applying an `.order()` clause. The type issue is resolved by using `var` for `finalQuery` to allow correct type inference.